### PR TITLE
docs: expand setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,28 @@ Prompts are structured to understand:
 - Chakra alignment
 - Suggest reflective practices (breathwork, journaling, action)
 
-## 🚀 Setup (WIP)
+## 🚀 Setup
+
+### Frontend
 
 ```bash
 git clone https://github.com/yourusername/7chakras.git
-cd 7chakras
-cd frontend
+cd 7chakras/frontend
+npm install
+cp .env.example .env # add your VITE_OPENAI_API_KEY
+npm run dev
+```
+
+> The app reads `VITE_OPENAI_API_KEY` from `.env` to access the OpenAI API. If the key is missing, AI features are skipped.
+
+### Optional Backend
+
+To enable syncing or analytics, run the optional Node.js backend in another terminal:
+
+```bash
+cd ../server
 npm install
 npm run dev
 ```
+
+The backend listens on port `3000` by default.

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,1 @@
+VITE_OPENAI_API_KEY=your_openai_api_key


### PR DESCRIPTION
## Summary
- add example environment file for frontend
- document OpenAI key and optional backend setup

## Testing
- `npm test` (frontend)
- `npm test` (server)

------
https://chatgpt.com/codex/tasks/task_e_68ab40483144832d807f81c2b1bb47b8